### PR TITLE
use q to select action to play at end of search rather than visits

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -123,7 +123,7 @@ impl Arena {
 
     // Section 3.4 https://project.dke.maastrichtuniversity.nl/games/files/phd/Chaslot_thesis.pdf
     fn final_move_selection(&self, ptr: ArenaIndex) -> Option<&Edge> {
-        let f = |edge: &Edge| edge.visits();
+        let f = |edge: &Edge| if edge.visits() == 0 { f32::NEG_INFINITY } else { edge.q() };
         self[ptr].edges().iter().max_by(|&e1, &e2| f(e1).partial_cmp(&f(e2)).unwrap())
     }
 


### PR DESCRIPTION
Elo   | 36.91 +- 10.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 5.00]
Games | N: 992 W: 186 L: 81 D: 725
Penta | [0, 61, 288, 128, 19]
https://chess.drpowell.org/test/361/
bench 4173824