### PR TITLE
Hashmap to store utility evals

### DIFF
--- a/src/hashtable.rs
+++ b/src/hashtable.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 #[derive(Default, Debug, Clone, Copy)]
 pub struct TableEntry {
     key: u16,
-    ptr: i32,
+    eval: f32,
 }
 
 #[derive(Debug)]
@@ -19,13 +19,12 @@ impl HashTable {
         Self { data }
     }
 
-    #[expect(unused)]
-    pub fn probe(&self, hash: u64) -> Option<i32> {
-        let idx = index(hash, self.data.len());
+    pub fn probe(&self, hash: u64) -> Option<f32> {
+        let idx = self.index(hash);
         let key = hash as u16;
         let entry = &self.data[idx];
         if entry.key == key {
-            return Some(entry.ptr);
+            return Some(entry.eval);
         }
         None
     }
@@ -36,18 +35,17 @@ impl HashTable {
         }
     }
 
-    #[expect(unused)]
-    pub fn insert(&mut self, hash: u64, ptr: i32) {
-        let idx = index(hash, self.data.len());
+    pub fn insert(&mut self, hash: u64, eval: f32) {
+        let idx = self.index(hash);
         let key = hash as u16;
-        self.data[idx] = TableEntry { key, ptr }
+        self.data[idx] = TableEntry { key, eval }
     }
 
     pub const fn len(&self) -> usize {
         self.data.len()
     }
-}
 
-fn index(hash: u64, table_capacity: usize) -> usize {
-    ((u128::from(hash) * (table_capacity as u128)) >> 64) as usize
+    fn index(&self, hash: u64) -> usize {
+        ((u128::from(hash) * (self.data.len() as u128)) >> 64) as usize
+    }
 }


### PR DESCRIPTION
bench: 1386741

Should be much more impactful when value net is larger...

Elo   | 10.22 +- 6.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 6328 W: 2180 L: 1994 D: 2154
Penta | [247, 665, 1209, 741, 302]
https://chess.drpowell.org/test/436/